### PR TITLE
매장에 복수 개 재료 추가 api, 주문 생성 api 추가 

### DIFF
--- a/src/shop/ingredient.entity.ts
+++ b/src/shop/ingredient.entity.ts
@@ -1,5 +1,7 @@
 export class Ingredient {
+  id: string;
   name: string;
   description: string;
+  price: number;
   thumbnail: string;
 }

--- a/src/shop/order.entity.ts
+++ b/src/shop/order.entity.ts
@@ -2,7 +2,7 @@ import { BaseEntity } from 'src/common/base.entity';
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { Ingredient } from './ingredient.entity';
 
-@Entity({ name: 'shops' })
+@Entity({ name: 'orders' })
 export class Order extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/shop/shop.controller.ts
+++ b/src/shop/shop.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { ShopService } from './shop.service';
 import { Shop } from './shop.entity';
 import { Ingredient } from './ingredient.entity';
+import { IngredientDto } from './dto/ingredient.dto';
 
 @Controller('shop')
 export class ShopController {
@@ -15,5 +16,10 @@ export class ShopController {
   @Get('/:shopId/ingredients')
   getIngredientsByShop(@Param(':shopId') shopId: number): Promise<Ingredient[]> {
     return this.shopService.getIngredientsByShop(shopId);
+  }
+
+  @Post('/:shopId/ingredients')
+  createIngredients(@Param(':shopId') shopId: number, @Body() ingredientDtos: IngredientDto[]): Promise<Shop> {
+    return this.shopService.addIngredients(shopId, ingredientDtos);
   }
 }

--- a/src/shop/shop.controller.ts
+++ b/src/shop/shop.controller.ts
@@ -3,6 +3,7 @@ import { ShopService } from './shop.service';
 import { Shop } from './shop.entity';
 import { Ingredient } from './ingredient.entity';
 import { IngredientDto } from './dto/ingredient.dto';
+import { ApiBody } from '@nestjs/swagger';
 
 @Controller('shop')
 export class ShopController {
@@ -18,8 +19,15 @@ export class ShopController {
     return this.shopService.getIngredientsByShop(shopId);
   }
 
+  @ApiBody({ type: [IngredientDto] })
   @Post('/:shopId/ingredients')
   createIngredients(@Param(':shopId') shopId: number, @Body() ingredientDtos: IngredientDto[]): Promise<Shop> {
     return this.shopService.addIngredients(shopId, ingredientDtos);
+  }
+
+  @ApiBody({ type: [IngredientDto] })
+  @Post('/:shopId/order')
+  createOrder(@Param(':shopId') shopId: number, @Body() ingerdientDtos: IngredientDto[]) {
+    return this.shopService.createOrder(shopId, ingerdientDtos);
   }
 }

--- a/src/shop/shop.entity.ts
+++ b/src/shop/shop.entity.ts
@@ -2,7 +2,7 @@ import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { Point } from 'geojson';
 import { Ingredient } from './ingredient.entity';
 
-@Entity({ name: 'shops' })
+@Entity({ name: 'shops', synchronize: false })
 export class Shop extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/shop/shop.module.ts
+++ b/src/shop/shop.module.ts
@@ -3,9 +3,10 @@ import { ShopController } from './shop.controller';
 import { ShopService } from './shop.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Shop } from './shop.entity';
+import { Order } from './order.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Shop])],
+  imports: [TypeOrmModule.forFeature([Shop, Order])],
   controllers: [ShopController],
   providers: [ShopService],
 })

--- a/src/shop/shop.service.ts
+++ b/src/shop/shop.service.ts
@@ -32,7 +32,7 @@ export class ShopService {
     return shop.ingredients;
   }
 
-  async addIngredients(shopId: number, dto: IngredientDto[]): Promise<Ingredient[]> {
+  async addIngredients(shopId: number, dto: IngredientDto[]): Promise<Shop> {
     const validationResult = await this.validateIngredients(shopId, dto);
     if (!validationResult) {
       throw new HttpException('validation fail', 400);
@@ -53,8 +53,7 @@ export class ShopService {
         thumbnail: dto.thumbnail,
       }),
     );
-    await this.shopRepository.save(shop);
-    return shop.ingredients;
+    return this.shopRepository.save(shop);
   }
 
   async createOrder(shopId: number, dto: IngredientDto[]): Promise<OrderDto> {

--- a/src/shop/shop.service.ts
+++ b/src/shop/shop.service.ts
@@ -13,7 +13,6 @@ export class ShopService {
   constructor(
     @InjectRepository(Shop)
     private readonly shopRepository: Repository<Shop>,
-
     @InjectRepository(Order)
     private readonly orderRepository: Repository<Order>,
   ) {}
@@ -44,15 +43,16 @@ export class ShopService {
       },
     });
 
-    dto.forEach((dto) =>
-      shop.ingredients.push({
+    dto.forEach((dto) => {
+      const newIngredient: Ingredient = {
         id: randomUUID(),
         price: dto.price,
         name: dto.name,
         description: dto.description,
         thumbnail: dto.thumbnail,
-      }),
-    );
+      };
+      shop.ingredients.push(newIngredient);
+    });
     return this.shopRepository.save(shop);
   }
 


### PR DESCRIPTION
다음의 두 가지 api를 추가합니다.
- `POST /{shopId}/ingredients` 매장에 복수 개의 재료 추가 api
- `POST /{shopId}/order` 매장에 대한 주문 생성 api 

여담이지만 dto 클래스의 배열을 body 로 받을 때는 (`ingredientDtos: IngredientDto[]`)
`@ApiBody` 어노테이션을 붙여야 스웨거 상 노출이 되네요.. 배워갑니다 