### PR TITLE
사용자 주문 목록 페이징 조회 api 추가

### DIFF
--- a/src/common/pagination/offset-pagination-option.ts
+++ b/src/common/pagination/offset-pagination-option.ts
@@ -3,7 +3,7 @@ import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
 import { PaginationOrder } from './pagination-order';
 import { Type } from 'class-transformer';
 
-export class PaginationOption {
+export class OffsetPaginationOption {
   @ApiPropertyOptional({ enum: PaginationOrder, default: PaginationOrder.ASC })
   @IsEnum(PaginationOrder)
   @IsOptional()

--- a/src/common/pagination/pagination-meta.ts
+++ b/src/common/pagination/pagination-meta.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaginationParameter } from './pagination-parameter';
+
+export class PaginationMeta {
+  @ApiProperty()
+  readonly page: number;
+
+  @ApiProperty()
+  readonly take: number;
+
+  @ApiProperty()
+  readonly itemCount: number;
+
+  @ApiProperty()
+  readonly pageCount: number;
+
+  @ApiProperty()
+  readonly hasPreviousPage: boolean;
+
+  @ApiProperty()
+  readonly hasNextPage: boolean;
+
+  constructor({ pageOption, itemCount }: PaginationParameter) {
+    this.page = pageOption.page;
+    this.take = pageOption.take;
+    this.itemCount = itemCount;
+    this.pageCount = Math.ceil(this.itemCount / this.take);
+    this.hasPreviousPage = this.page > 1;
+    this.hasNextPage = this.page < this.pageCount;
+  }
+}

--- a/src/common/pagination/pagination-option.ts
+++ b/src/common/pagination/pagination-option.ts
@@ -1,0 +1,37 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { PaginationOrder } from './pagination-order';
+import { Type } from 'class-transformer';
+
+export class PaginationOption {
+  @ApiPropertyOptional({ enum: PaginationOrder, default: PaginationOrder.ASC })
+  @IsEnum(PaginationOrder)
+  @IsOptional()
+  readonly order?: PaginationOrder = PaginationOrder.ASC;
+
+  @ApiPropertyOptional({
+    minimum: 1,
+    default: 1,
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  readonly page?: number = 1;
+
+  @ApiPropertyOptional({
+    minimum: 1,
+    maximum: 50,
+    default: 10,
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  @IsOptional()
+  readonly take?: number = 10;
+
+  get skip(): number {
+    return (this.page - 1) * this.take;
+  }
+}

--- a/src/common/pagination/pagination-order.ts
+++ b/src/common/pagination/pagination-order.ts
@@ -1,0 +1,4 @@
+export enum PaginationOrder {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}

--- a/src/common/pagination/pagination-parameter.ts
+++ b/src/common/pagination/pagination-parameter.ts
@@ -1,6 +1,6 @@
-import { PaginationOption } from './pagination-option';
+import { OffsetPaginationOption } from './offset-pagination-option';
 
 export interface PaginationParameter {
-  pageOption: PaginationOption;
+  pageOption: OffsetPaginationOption;
   itemCount: number;
 }

--- a/src/common/pagination/pagination-parameter.ts
+++ b/src/common/pagination/pagination-parameter.ts
@@ -1,0 +1,6 @@
+import { PaginationOption } from './pagination-option';
+
+export interface PaginationParameter {
+  pageOption: PaginationOption;
+  itemCount: number;
+}

--- a/src/common/pagination/pagination-response.ts
+++ b/src/common/pagination/pagination-response.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray } from 'class-validator';
+import { PaginationMeta } from './pagination-meta';
+
+export class PageResponse<T> {
+  @IsArray()
+  @ApiProperty({ isArray: true })
+  readonly data: T[];
+
+  @ApiProperty({ type: () => PaginationMeta })
+  readonly meta: PaginationMeta;
+
+  constructor(data: T[], meta: PaginationMeta) {
+    this.data = data;
+    this.meta = meta;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,13 +10,14 @@ async function bootstrap() {
     new ValidationPipe({
       whitelist: true,
       skipMissingProperties: true,
-    })
+      transform: true,
+    }),
   );
   app.enableCors({
-    origin: "*",
-    methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
+    origin: '*',
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
     preflightContinue: false,
-    optionsSuccessStatus: 204
+    optionsSuccessStatus: 204,
   });
   await app.listen(3000);
 }

--- a/src/shop/dto/order.dto.ts
+++ b/src/shop/dto/order.dto.ts
@@ -2,18 +2,19 @@ import { ApiProperty } from '@nestjs/swagger';
 import { OrderType } from 'src/common/domain/order-type';
 import { Ingredient } from '../entity/ingredient.entity';
 import { Order } from '../entity/order.entity';
+import { Type } from 'class-transformer';
 
 export class OrderDto {
   @ApiProperty()
   orderId: number;
 
-  @ApiProperty({ type: 'enum', enum: OrderType, example: 'TO_GO' })
+  @ApiProperty({ type: 'enum', enum: OrderType, example: 'TO_GO', description: '주문 타입' })
   type: OrderType;
 
-  @ApiProperty()
+  @ApiProperty({ type: BigInt, description: '주문 총 금액' })
   priceSum: BigInt;
 
-  @ApiProperty()
+  @ApiProperty({ type: Ingredient, description: '주문에 포함된 재료 목록' })
   ingredients: Ingredient[];
 
   static fromEntity(entity: Order): OrderDto {

--- a/src/shop/dto/order.dto.ts
+++ b/src/shop/dto/order.dto.ts
@@ -17,11 +17,15 @@ export class OrderDto {
   @ApiProperty({ type: Ingredient, description: '주문에 포함된 재료 목록' })
   ingredients: Ingredient[];
 
+  @ApiProperty({ type: 'number', description: '주문 매장 id' })
+  shopId: number;
+
   static fromEntity(entity: Order): OrderDto {
     const dto = new OrderDto();
     dto.orderId = entity.id;
     dto.type = entity.type;
     dto.priceSum = entity.priceSum;
+    dto.shopId = entity.shopId;
     dto.ingredients = entity.ingredients;
     return dto;
   }

--- a/src/shop/dto/order.dto.ts
+++ b/src/shop/dto/order.dto.ts
@@ -1,5 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { OrderType } from 'src/common/domain/order-type';
+import { Ingredient } from '../entity/ingredient.entity';
+import { Order } from '../entity/order.entity';
 
 export class OrderDto {
   @ApiProperty()
@@ -7,4 +9,19 @@ export class OrderDto {
 
   @ApiProperty({ type: 'enum', enum: OrderType, example: 'TO_GO' })
   type: OrderType;
+
+  @ApiProperty()
+  priceSum: BigInt;
+
+  @ApiProperty()
+  ingredients: Ingredient[];
+
+  static fromEntity(entity: Order): OrderDto {
+    const dto = new OrderDto();
+    dto.orderId = entity.id;
+    dto.type = entity.type;
+    dto.priceSum = entity.priceSum;
+    dto.ingredients = entity.ingredients;
+    return dto;
+  }
 }

--- a/src/shop/entity/ingredient.entity.ts
+++ b/src/shop/entity/ingredient.entity.ts
@@ -1,7 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class Ingredient {
+  @ApiProperty()
   id: string;
+
+  @ApiProperty({ description: '재료 이름' })
   name: string;
+
+  @ApiProperty({ description: '재료 설명' })
   description: string;
+
+  @ApiProperty({ description: '재료 가격' })
   price: number;
+
+  @ApiProperty({ description: '재료 썸네일' })
   thumbnail: string;
 }

--- a/src/shop/entity/order.entity.ts
+++ b/src/shop/entity/order.entity.ts
@@ -8,6 +8,9 @@ export class Order extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column({ type: 'int' })
+  userId: number;
+
   @Column({ type: 'bigint' })
   priceSum: BigInt;
 

--- a/src/shop/entity/order.entity.ts
+++ b/src/shop/entity/order.entity.ts
@@ -11,6 +11,9 @@ export class Order extends BaseEntity {
   @Column({ type: 'int' })
   userId: number;
 
+  @Column({ type: 'int' })
+  shopId: number;
+
   @Column({ type: 'bigint' })
   priceSum: BigInt;
 

--- a/src/shop/shop.controller.ts
+++ b/src/shop/shop.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { ShopService } from './shop.service';
 import { Shop } from './shop.entity';
 import { Ingredient } from './entity/ingredient.entity';
@@ -6,6 +6,8 @@ import { IngredientDto } from './dto/ingredient.dto';
 import { ApiBody, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { OrderDto } from './dto/order.dto';
+import { PageResponse } from 'src/common/pagination/pagination-response';
+import { PaginationOption } from 'src/common/pagination/pagination-option';
 
 @Controller('shop')
 export class ShopController {
@@ -42,8 +44,8 @@ export class ShopController {
   @ApiOperation({ summary: '주문 목록 조회', description: '사용자가 생성한 주문 조회' })
   @ApiOkResponse({ type: OrderDto, isArray: true })
   @Get('/orders')
-  getOrders(): Promise<OrderDto[]> {
+  getOrders(@Query() pageOption: PaginationOption): Promise<PageResponse<OrderDto>> {
     const userId = 1;
-    return this.shopService.getOrdersByUserId(userId);
+    return this.shopService.getOrdersByUserId(userId, pageOption);
   }
 }

--- a/src/shop/shop.controller.ts
+++ b/src/shop/shop.controller.ts
@@ -7,7 +7,7 @@ import { ApiBody, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { OrderDto } from './dto/order.dto';
 import { PageResponse } from 'src/common/pagination/pagination-response';
-import { PaginationOption } from 'src/common/pagination/pagination-option';
+import { OffsetPaginationOption } from 'src/common/pagination/offset-pagination-option';
 
 @Controller('shop')
 export class ShopController {
@@ -44,7 +44,7 @@ export class ShopController {
   @ApiOperation({ summary: '주문 목록 조회', description: '사용자가 생성한 주문 조회' })
   @ApiOkResponse({ type: OrderDto, isArray: true })
   @Get('/orders')
-  getOrders(@Query() pageOption: PaginationOption): Promise<PageResponse<OrderDto>> {
+  getOrders(@Query() pageOption: OffsetPaginationOption): Promise<PageResponse<OrderDto>> {
     const userId = 1;
     return this.shopService.getOrdersByUserId(userId, pageOption);
   }

--- a/src/shop/shop.controller.ts
+++ b/src/shop/shop.controller.ts
@@ -35,6 +35,7 @@ export class ShopController {
   @ApiBody({ type: [CreateOrderDto] })
   @Post('/:shopId/order')
   createOrder(@Param(':shopId') shopId: number, @Body() createOrder: CreateOrderDto) {
-    return this.shopService.createOrder(shopId, createOrder.ingredientIds, createOrder.type);
+    const userId = 1;
+    return this.shopService.createOrder(shopId, userId, createOrder.ingredientIds, createOrder.type);
   }
 }

--- a/src/shop/shop.controller.ts
+++ b/src/shop/shop.controller.ts
@@ -34,8 +34,16 @@ export class ShopController {
   @ApiOkResponse({ description: '정상적으로 주문 생성 완료', type: OrderDto })
   @ApiBody({ type: [CreateOrderDto] })
   @Post('/:shopId/order')
-  createOrder(@Param(':shopId') shopId: number, @Body() createOrder: CreateOrderDto) {
+  createOrder(@Param(':shopId') shopId: number, @Body() createOrder: CreateOrderDto): Promise<OrderDto> {
     const userId = 1;
     return this.shopService.createOrder(shopId, userId, createOrder.ingredientIds, createOrder.type);
+  }
+
+  @ApiOperation({ summary: '주문 목록 조회', description: '사용자가 생성한 주문 조회' })
+  @ApiOkResponse({ type: OrderDto, isArray: true })
+  @Get('/orders')
+  getOrders(): Promise<OrderDto[]> {
+    const userId = 1;
+    return this.shopService.getOrdersByUserId(userId);
   }
 }

--- a/src/shop/shop.service.ts
+++ b/src/shop/shop.service.ts
@@ -76,6 +76,7 @@ export class ShopService {
 
     const newOrder = new Order();
     newOrder.ingredients = orderIngredients;
+    newOrder.shopId = shopId;
     newOrder.type = type;
     newOrder.userId = userId;
     newOrder.priceSum = BigInt(orderIngredients.map((dto) => dto.price).reduce((sum, current) => sum + current, 0));

--- a/src/shop/shop.service.ts
+++ b/src/shop/shop.service.ts
@@ -57,7 +57,7 @@ export class ShopService {
     return this.shopRepository.save(shop);
   }
 
-  async createOrder(shopId: number, ingredients: string[], type: OrderType): Promise<OrderDto> {
+  async createOrder(shopId: number, userId: number, ingredients: string[], type: OrderType): Promise<OrderDto> {
     const shop = await this.shopRepository.findOne({
       where: {
         id: shopId,
@@ -74,6 +74,7 @@ export class ShopService {
     const newOrder = new Order();
     newOrder.ingredients = orderIngredients;
     newOrder.type = type;
+    newOrder.userId = userId;
     newOrder.priceSum = BigInt(orderIngredients.map((dto) => dto.price).reduce((sum, current) => sum + current, 0));
 
     await this.orderRepository.save(newOrder);

--- a/src/shop/shop.service.ts
+++ b/src/shop/shop.service.ts
@@ -77,11 +77,20 @@ export class ShopService {
     newOrder.userId = userId;
     newOrder.priceSum = BigInt(orderIngredients.map((dto) => dto.price).reduce((sum, current) => sum + current, 0));
 
-    await this.orderRepository.save(newOrder);
-    return {
-      orderId: newOrder.id,
-      type: type,
-    };
+    return await this.orderRepository.save(newOrder).then((entity) => OrderDto.fromEntity(entity));
+  }
+
+  async getOrdersByUserId(userId: number): Promise<OrderDto[]> {
+    return await this.orderRepository
+      .find({
+        where: {
+          userId: userId,
+        },
+        order: {
+          created_at: 'DESC',
+        },
+      })
+      .then((entities) => entities.map((entity) => OrderDto.fromEntity(entity)));
   }
 
   private async validateIngredients(shopId: number, dto: IngredientDto[]): Promise<boolean> {

--- a/src/shop/shop.service.ts
+++ b/src/shop/shop.service.ts
@@ -8,7 +8,7 @@ import { randomUUID } from 'crypto';
 import { Order } from './entity/order.entity';
 import { OrderDto } from './dto/order.dto';
 import { OrderType } from 'src/common/domain/order-type';
-import { PaginationOption } from 'src/common/pagination/pagination-option';
+import { OffsetPaginationOption } from 'src/common/pagination/offset-pagination-option';
 import { PageResponse } from 'src/common/pagination/pagination-response';
 import { PaginationMeta } from 'src/common/pagination/pagination-meta';
 
@@ -84,7 +84,7 @@ export class ShopService {
     return await this.orderRepository.save(newOrder).then((entity) => OrderDto.fromEntity(entity));
   }
 
-  async getOrdersByUserId(userId: number, pageOption: PaginationOption): Promise<PageResponse<OrderDto>> {
+  async getOrdersByUserId(userId: number, pageOption: OffsetPaginationOption): Promise<PageResponse<OrderDto>> {
     const queryBuilder = this.orderRepository.createQueryBuilder('getOrdersByUserId');
 
     queryBuilder


### PR DESCRIPTION
### 작업 내용
- 페이지네이션 공통 클래스들 추가 (`PageResponse<T>`)
- 임의의 `userId` 로 생성한 주문 목록 페이지네이션 조회 api 추가
- 주문 엔티티에 그동안 매핑되지 않고 있던 `userId`, `shopId` 멤버 추가

### 작업 배경

https://github.com/TEAM-LEG3ND/kopi-luwak-docs/discussions/18#discussioncomment-9263292
https://github.com/TEAM-LEG3ND/luwak/pull/33 머지 이후에 조금 더 깔끔하게 보입니다. 