### PR TITLE
주문 단건 조회 api 추가

### DIFF
--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -41,10 +41,6 @@ export class PaymentService {
       throw new HttpException('[Payment Error] order data not found', 404);
     }
 
-    if (order.priceSum !== BigInt(amount)) {
-      throw new HttpException('[Payment Error] payment amount validation fail', 400);
-    }
-
     // toss payment 요청
     const newPayment = new Payment();
     newPayment.paymentKey = paymentKey;

--- a/src/shop/dto/create-order.dto.ts
+++ b/src/shop/dto/create-order.dto.ts
@@ -1,18 +1,23 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsEnum } from 'class-validator';
 import { PackageType } from 'src/common/domain/package-type';
 import { SizeType } from 'src/common/domain/size-type';
 import { TemperatureType } from 'src/common/domain/temperature-type';
 
 export class CreateOrderDto {
   @ApiProperty()
+  @IsArray()
   ingredientIds: string[];
 
   @ApiProperty({ type: 'enum', enum: PackageType, example: 'TO_GO' })
+  @IsEnum(PackageType)
   packageType: PackageType;
 
   @ApiProperty({ type: 'enum', enum: TemperatureType, example: 'ICE' })
+  @IsEnum(TemperatureType)
   temperatureType: TemperatureType;
 
   @ApiProperty({ type: 'enum', enum: SizeType, example: 'SMALL' })
+  @IsEnum(SizeType)
   sizeType: SizeType;
 }

--- a/src/shop/dto/order.dto.ts
+++ b/src/shop/dto/order.dto.ts
@@ -18,8 +18,8 @@ export class OrderDto {
   @ApiProperty({ type: 'enum', enum: TemperatureType, example: 'ICE', description: '음료 온도 타입' })
   temperatureType: TemperatureType;
 
-  @ApiProperty({ type: BigInt, description: '주문 총 금액' })
-  priceSum: BigInt;
+  @ApiProperty({ type: 'string', description: '주문 총 금액' })
+  priceSum: string;
 
   @ApiProperty({ type: Ingredient, description: '주문에 포함된 재료 목록' })
   ingredients: Ingredient[];

--- a/src/shop/entity/order.entity.ts
+++ b/src/shop/entity/order.entity.ts
@@ -18,7 +18,7 @@ export class Order extends BaseEntity {
   shopId: number;
 
   @Column({ type: 'bigint' })
-  priceSum: BigInt;
+  priceSum: string;
 
   @Column({ type: 'enum', enum: SizeType })
   size: SizeType;

--- a/src/shop/shop.controller.ts
+++ b/src/shop/shop.controller.ts
@@ -40,8 +40,7 @@ export class ShopController {
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: '주문 생성', description: '해당 매장에 주문 생성' })
   @ApiOkResponse({ description: '정상적으로 주문 생성 완료', type: OrderDto })
-  @UseGuards(JwtAuthGuard)
-  @ApiBody({ type: [CreateOrderDto] })
+  @ApiBody({ type: CreateOrderDto })
   @Post('/:shopId/order')
   createOrder(
     @Param('shopId') shopId: number,
@@ -53,12 +52,20 @@ export class ShopController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @ApiOperation({ summary: '주문 목록 조회', description: '사용자가 생성한 주문 조회' })
+  @ApiOperation({ summary: '주문 목록 조회', description: '사용자가 생성한 주문 목록 조회' })
   @ApiOkResponse({ type: OrderDto, isArray: true })
-  @UseGuards(JwtAuthGuard)
   @Get('/orders')
   getOrders(@Query() pageOption: OffsetPaginationOption, @Auth() user: User): Promise<PageResponse<OrderDto>> {
     const userId = user.id;
     return this.shopService.getOrdersByUserId(userId, pageOption);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '주문 단건 조회', description: '사용자가 생성한 주문 단건 조회' })
+  @ApiOkResponse({ type: OrderDto, isArray: false })
+  @Get('/orders/:orderId')
+  getOrder(@Auth() user: User, @Param('orderId') orderId: string): Promise<OrderDto> {
+    const userId = user.id;
+    return this.shopService.getOrdersByOrderIdAndUser(userId, orderId);
   }
 }

--- a/src/shop/shop.entity.ts
+++ b/src/shop/shop.entity.ts
@@ -13,7 +13,15 @@ export class Shop {
   @Column()
   description: string;
 
-  @Column({ type: 'point', nullable: true, spatialFeatureType: 'Point' })
+  @Column({
+    type: 'point',
+    nullable: true,
+    spatialFeatureType: 'Point',
+    transformer: {
+      from: (v) => v,
+      to: (v) => `${v.x}, ${v.y}`,
+    },
+  })
   location: Point;
 
   @Column({ type: 'json' })

--- a/src/shop/shop.service.ts
+++ b/src/shop/shop.service.ts
@@ -90,6 +90,31 @@ export class ShopService {
     return await this.orderRepository.save(newOrder).then((entity) => OrderDto.fromEntity(entity));
   }
 
+  async getOrdersByOrderIdAndUser(userId: number, orderId: string, pageOption: OffsetPaginationOption): Promise<PageResponse<OrderDto> {
+    const queryBuilder = this.orderRepository.createQueryBuilder('getOrdersByOrderIdAndUser');
+
+    queryBuilder
+    .orderBy('createdAt', pageOption.order)
+    .skip(pageOption.skip)
+    .take(pageOption.take)
+    .where({
+      where: {
+        userId: userId,
+        orderId: orderId
+      }
+    });
+
+    const count = await queryBuilder.getCount();
+    const { entities } = await queryBuilder.getRawAndEntities();
+
+    const pageMeta = new PaginationMeta({ pageOption: pageOption, itemCount: count });
+
+    return new PageResponse(
+      entities.map((entity) => OrderDto.fromEntity(entity)),
+      pageMeta,
+    );
+  }
+
   async getOrdersByUserId(userId: number, pageOption: OffsetPaginationOption): Promise<PageResponse<OrderDto>> {
     const queryBuilder = this.orderRepository.createQueryBuilder('getOrdersByUserId');
 

--- a/src/shop/shop.service.ts
+++ b/src/shop/shop.service.ts
@@ -7,14 +7,12 @@ import { IngredientDto } from './dto/ingredient.dto';
 import { randomUUID } from 'crypto';
 import { Order } from './entity/order.entity';
 import { OrderDto } from './dto/order.dto';
-import { PackageType } from 'src/common/domain/package-type';
 import { OffsetPaginationOption } from 'src/common/pagination/offset-pagination-option';
 import { PageResponse } from 'src/common/pagination/pagination-response';
 import { PaginationMeta } from 'src/common/pagination/pagination-meta';
 import { ShopDto } from './dto/shop.dto';
-import { SizeType } from 'src/common/domain/size-type';
-import { TemperatureType } from 'src/common/domain/temperature-type';
 import { CreateOrderDto } from './dto/create-order.dto';
+import { OrderStatus } from 'src/common/domain/order-status';
 
 @Injectable()
 export class ShopService {
@@ -75,7 +73,7 @@ export class ShopService {
     const orderIngredients = shop.ingredients.filter((ingredient) => targetIngredients.has(ingredient.id));
 
     if (shop == null || targetIngredients.size === 0 || orderIngredients.length === 0) {
-      throw new HttpException('validation fail', 400);
+      throw new HttpException('validation fail: shop not have such ', 400);
     }
 
     const newOrder = new Order();
@@ -85,34 +83,22 @@ export class ShopService {
     newOrder.temperature = createOrderDto.temperatureType;
     newOrder.package = createOrderDto.packageType;
     newOrder.userId = userId;
-    newOrder.priceSum = BigInt(orderIngredients.map((dto) => dto.price).reduce((sum, current) => sum + current, 0));
+    newOrder.priceSum = BigInt(
+      orderIngredients.map((dto) => dto.price).reduce((sum, current) => sum + current, 0),
+    ).toString();
+    newOrder.status = OrderStatus.READY;
 
     return await this.orderRepository.save(newOrder).then((entity) => OrderDto.fromEntity(entity));
   }
 
-  async getOrdersByOrderIdAndUser(userId: number, orderId: string, pageOption: OffsetPaginationOption): Promise<PageResponse<OrderDto> {
-    const queryBuilder = this.orderRepository.createQueryBuilder('getOrdersByOrderIdAndUser');
-
-    queryBuilder
-    .orderBy('createdAt', pageOption.order)
-    .skip(pageOption.skip)
-    .take(pageOption.take)
-    .where({
+  async getOrdersByOrderIdAndUser(userId: number, orderId: string): Promise<OrderDto> {
+    const order = await this.orderRepository.findOne({
       where: {
+        id: orderId,
         userId: userId,
-        orderId: orderId
-      }
+      },
     });
-
-    const count = await queryBuilder.getCount();
-    const { entities } = await queryBuilder.getRawAndEntities();
-
-    const pageMeta = new PaginationMeta({ pageOption: pageOption, itemCount: count });
-
-    return new PageResponse(
-      entities.map((entity) => OrderDto.fromEntity(entity)),
-      pageMeta,
-    );
+    return OrderDto.fromEntity(order);
   }
 
   async getOrdersByUserId(userId: number, pageOption: OffsetPaginationOption): Promise<PageResponse<OrderDto>> {
@@ -138,13 +124,7 @@ export class ShopService {
   private async validateIngredients(shopId: number, dto: IngredientDto[]): Promise<boolean> {
     const nonNull = dto.every((dto) => dto.name != null && dto.thumbnail != null);
     const priceValid = dto.every((dto) => dto.price >= 0);
-    const shop = await this.shopRepository.findOne({
-      where: {
-        id: shopId,
-      },
-    });
-    const shopIngredientsId = shop.ingredients.map((entity) => entity.id);
-    const ingredientsValid = dto.map((dto) => dto.id).every((dtoId) => shopIngredientsId.includes(dtoId));
-    return nonNull && priceValid && ingredientsValid;
+    console.log(nonNull, priceValid);
+    return nonNull && priceValid;
   }
 }


### PR DESCRIPTION
주문 단건 조회 api 추가 및 be 전체 플로우 재점검 완료했습니다.

- 로그인
- 로그인 후 매장 조회
- 매장 조회 후 재료 목록 조회
- 주문 생성
- 주문 목록 조회
- 주문 단건 조회
까지 정상 동작 확인했습니다. 

### PR Point

#### 1. bigint serialize 문제

postgresql 컬럼 타입이 bigint로 저장되는데 이걸 때려 죽어도 serialize 못하는 문제가 있었습니다.  
```bash
[Nest] 2140  - 2024. 06. 09. 오후 4:12:42   ERROR [ExceptionsHandler] Do not know how to serialize a BigInt
TypeError: Do not know how to serialize a BigInt
```

https://darraghoriordan.medium.com/postgresql-and-typeorm-advanced-querying-e5d8e4c950d6

다행히도 entity 필드 타입을 `string`으로 지정해주니 잘 알아먹긴 하는데, 요거 해결책 아시는 분은 PR 반영 부탁드리겠습니다...
(관련 모듈인 payment에도 반영 완료)

#### 2. 매장 재료 추가 api에서 shop 저장하지 못하는 문제

1번과 비슷한 결에서 postgresql `point` 타입을 serialize하지 못하는 문제가 있었습니다.
다행히도 요녀석은 `@Column`에 `transformers` 옵션 추가하여 해결하였습니다.

```ts
@Column({
    type: 'point',
    nullable: true,
    spatialFeatureType: 'Point',
    transformer: {
      from: (v) => v,
      to: (v) => `${v.x}, ${v.y}`,
    },
  })
```

#### 3. dto deserialize 문제

`@Body()` 데코레이터로 받는 `createOrder` dto 가 계속 undefined 로 받아지는 문제가 있었습니다.
class-transformer 적용하지 않으면 enum 타입을 deserialize 못하는 것 같네요
`@IsEnum` 데코레이터 추가해주니 정상 동작했습니다. 


#### 4. order 테이블 신규 타입 컬럼 추가되지 않았던 문제

아마 요거 때문에 그동안 매장 api 500 떴지 싶은데, 지난 pr 병합 이후 주문 엔티티에 신규 enum 필드들이 추가되었었는데
실제 개발 db에는 해당 컬럼이 없어서 에러가 발생하고 있었습니다.

order 테이블 드랍 이후 신규 생성해서 자동으로 엔티티에 먹여진 enum 필드 생성하도록 하여 조치하였습니다. 